### PR TITLE
fixed bug encountered when fetching source specified by a file path

### DIFF
--- a/mod_pybombs/fetch.py
+++ b/mod_pybombs/fetch.py
@@ -147,7 +147,6 @@ class fetcher:
             stat = shellexec_shell("tar xzf %s"%(fn), False);
             if(stat != 0):
                 return False;
-            rmrf(self.recipe.name);
             os.rename(dirname, self.recipe.name);
         elif(re.match(r'.*\.tar.bz2?', fn) or re.match(r'.*\.tbz2?', fn)):
             out = shellexec(["tar tbjB 1 --file %s"%(fn)]);


### PR DESCRIPTION
I found this when testing with uncommited local git repos. Using "file:///path/to/repo.tar.gz" in a recipe file causes the fetch process to bomb. This worked before the change was made to symlink tar.gz files in the src directory instead of copying them. 

This edit may fix the symptom rather than the disease, however internal use has shown that the fix is adequate. 